### PR TITLE
[FE] 채팅방 메시지 발신자 이름 표시 구현

### DIFF
--- a/components/ChatRoomView.tsx
+++ b/components/ChatRoomView.tsx
@@ -42,42 +42,41 @@ export const ChatRoomView: React.FC<{
                 transparent={false}
             />
             
-            {/* Dropdown Menu */}
+            {/* 드롭다운 메뉴 */}
             {showMenu && (
                 <>
-                <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)}></div>
-                <div className="absolute top-14 right-4 z-50 bg-white shadow-xl rounded-xl border border-gray-100 p-1.5 min-w-[160px] animate-in fade-in zoom-in-95 duration-200">
-                    <button 
-                        onClick={() => { setShowParticipants(true); setShowMenu(false); }}
-                        className="w-full text-left px-4 py-3 hover:bg-gray-50 rounded-lg text-sm font-medium text-gray-700 flex items-center gap-2 transition-colors"
-                    >
-                        <Users size={16} className="text-gray-500" /> 대화상대 ({participantsInfo.length})
-                    </button>
-                    <div className="h-px bg-gray-50 my-1"></div>
-                    <button 
-                        onClick={() => { if(window.confirm('정말 채팅방을 나가시겠습니까? 대화 내용이 삭제될 수 있습니다.')) onLeave(); }}
-                        className="w-full text-left px-4 py-3 hover:bg-red-50 rounded-lg text-sm font-medium text-red-500 flex items-center gap-2 transition-colors"
-                    >
-                        <LogOut size={16} /> 채팅방 나가기
-                    </button>
-                </div>
+                    <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)}></div>
+                    <div className="absolute top-14 right-4 z-50 bg-white shadow-xl rounded-xl border border-gray-100 p-1.5 min-w-[160px] animate-in fade-in zoom-in-95 duration-200">
+                        <button 
+                            onClick={() => { setShowParticipants(true); setShowMenu(false); }}
+                            className="w-full text-left px-4 py-3 hover:bg-gray-50 rounded-lg text-sm font-medium text-gray-700 flex items-center gap-2 transition-colors"
+                        >
+                            <Users size={16} className="text-gray-500" /> 대화상대 ({participantsInfo.length})
+                        </button>
+                        <div className="h-px bg-gray-50 my-1"></div>
+                        <button 
+                            onClick={() => { if(window.confirm('정말 채팅방을 나가시겠습니까? 대화 내용이 삭제될 수 있습니다.')) onLeave(); }}
+                            className="w-full text-left px-4 py-3 hover:bg-red-50 rounded-lg text-sm font-medium text-red-500 flex items-center gap-2 transition-colors"
+                        >
+                            <LogOut size={16} /> 채팅방 나가기
+                        </button>
+                    </div>
                 </>
             )}
 
-            {/* Participants Modal */}
+            {/* 참여자 목록 모달 */}
             {showParticipants && (
                  <div className="fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 animate-in fade-in duration-200" onClick={() => setShowParticipants(false)}>
                     <div className="bg-white w-full max-w-xs rounded-3xl p-6 shadow-2xl transform transition-all scale-100" onClick={e => e.stopPropagation()}>
-                       <div className="flex justify-between items-center mb-5">
-                           <h3 className="font-bold text-lg text-gray-900">대화상대</h3>
-                           <button onClick={() => setShowParticipants(false)} className="text-gray-400 hover:text-gray-600"><X size={20}/></button>
-                       </div>
-                       <div className="space-y-4 max-h-[300px] overflow-y-auto pr-1">
+                        <div className="flex justify-between items-center mb-5">
+                            <h3 className="font-bold text-lg text-gray-900">대화상대</h3>
+                            <button onClick={() => setShowParticipants(false)} className="text-gray-400 hover:text-gray-600"><X size={20}/></button>
+                        </div>
+                        <div className="space-y-4 max-h-[300px] overflow-y-auto pr-1">
                           {participantsInfo.map(user => (
                              <div key={user.id} className="flex items-center gap-3">
                                 <div className="relative">
-                                    <img src={user.avatarUrl} className="w-10 h-10 rounded-full bg-gray-200 object-cover border border-gray-100"/>
-                                    {/* 'Me' Badge = Dark Gray */}
+                                    <img src={user.avatarUrl} alt={user.name} className="w-10 h-10 rounded-full bg-gray-200 object-cover border border-gray-100"/>
                                     {user.id === CURRENT_USER.id && <div className="absolute -bottom-1 -right-1 bg-gray-900 text-white text-[9px] px-1.5 py-0.5 rounded-full border border-white font-bold">나</div>}
                                 </div>
                                 <div className="flex-1 min-w-0">
@@ -86,25 +85,38 @@ export const ChatRoomView: React.FC<{
                                 </div>
                              </div>
                           ))}
-                       </div>
+                        </div>
                     </div>
                  </div>
             )}
             
-            <div className="flex-1 overflow-y-auto pt-16 pb-20 px-4 space-y-4">
-                {chatRoom.messages.map((msg, index) => {
+            {/* 채팅 메시지 영역 */}
+            <div className="flex-1 overflow-y-auto pt-16 pb-20 px-4 space-y-6">
+                {chatRoom.messages.map((msg) => {
                     const isMe = msg.senderId === CURRENT_USER.id;
+                    // 메시지 보낸 사람 정보 찾기
+                    const sender = participantsInfo.find(u => u.id === msg.senderId);
+                    const senderName = sender ? sender.name : '알 수 없는 사용자';
+
                     return (
-                        <div key={msg.id} className={`flex ${isMe ? 'justify-end' : 'justify-start'}`}>
-                            {/* Message Bubble = Gray 900 for Me */}
-                            <div className={`max-w-[75%] rounded-2xl px-4 py-2.5 text-sm shadow-sm ${
-                                isMe 
-                                ? 'bg-gray-900 text-white rounded-tr-none' 
-                                : 'bg-white text-gray-800 rounded-tl-none border border-gray-200'
-                            }`}>
-                                {msg.text}
-                                <div className={`text-[10px] mt-1 text-right ${isMe ? 'text-gray-400' : 'text-gray-400'}`}>
-                                    {new Date(msg.timestamp).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}
+                        <div key={msg.id} className={`flex flex-col ${isMe ? 'items-end' : 'items-start'}`}>
+                            {/* 상대방일 때만 말풍선 위에 이름 표시 */}
+                            {!isMe && (
+                                <span className="text-[11px] font-bold text-gray-600 mb-1 ml-1">
+                                    {senderName}
+                                </span>
+                            )}
+                            
+                            <div className={`flex ${isMe ? 'justify-end' : 'justify-start'} w-full`}>
+                                <div className={`max-w-[75%] rounded-2xl px-4 py-2.5 text-sm shadow-sm ${
+                                    isMe 
+                                    ? 'bg-gray-900 text-white rounded-tr-none' 
+                                    : 'bg-white text-gray-800 rounded-tl-none border border-gray-200'
+                                }`}>
+                                    {msg.text}
+                                    <div className={`text-[10px] mt-1 text-right ${isMe ? 'text-gray-400' : 'text-gray-500'}`}>
+                                        {new Date(msg.timestamp).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -113,6 +125,7 @@ export const ChatRoomView: React.FC<{
                 <div ref={messagesEndRef} />
             </div>
 
+            {/* 메시지 입력창 */}
             <div className="fixed bottom-0 left-0 right-0 p-3 bg-white border-t border-gray-100 max-w-md mx-auto">
                 <form onSubmit={handleSend} className="flex gap-2">
                     <input 

--- a/constants.ts
+++ b/constants.ts
@@ -134,7 +134,7 @@ export const MOCK_CHATS: ChatRoom[] = [
     lastMessage: "3번 출구 앞에서 뵙겠습니다!",
     lastMessageTime: "오전 10:30",
     unreadCount: 2,
-    participants: [1, 2],
+    participants: [1, 2, 3],
     messages: [
       {
         id: 1,
@@ -152,6 +152,12 @@ export const MOCK_CHATS: ChatRoom[] = [
         id: 3,
         senderId: 2,
         text: "3번 출구 앞에서 뵙겠습니다!",
+        timestamp: Date.now() - 3600000,
+      },
+      {
+        id: 4,
+        senderId: 3,
+        text: "저도!! 3번 출구 앞에서 뵙겠습니다!",
         timestamp: Date.now() - 3600000,
       },
     ],


### PR DESCRIPTION
### 📌 개요
채팅방에서 여러 명의 사용자가 대화할 때 발신자를 쉽게 식별할 수 있도록 메시지 말풍선 위에 사용자 이름을 표시하는 기능을 추가했습니다.
### ⭐ 관련 이슈
- closes #10

### 🛠️ 작업 내용
- [x] `ChatRoomView` 컴포넌트 내 메시지 렌더링 로직 수정
- [x] `participantsInfo` 데이터를 활용해 발신자(`senderName`) 매칭 로직 추가
- [x] 상대방 메시지에만 이름이 표시되도록 조건부 렌더링 적용
- [x] 이름 표시를 위한 Flexbox 레이아웃, 타이포그래피 스타일 조정

### 📸 화면
<p>
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/daff758d-da81-4e7c-b54c-bc43909f16dd" />
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/f533bbff-b739-4b6c-a5c7-f4a429aedc16" />
</p><br>

**궁금하신 부분이 있다면, 댓글 달아주세요! 😊**